### PR TITLE
fix: accept cache if there is no headSha

### DIFF
--- a/packages/server/src/server/middleware/app.ts
+++ b/packages/server/src/server/middleware/app.ts
@@ -45,7 +45,7 @@ appMiddleware.get(
         permission,
         changeLogState,
         currentVersions:
-          packageInfoCache && packageInfoCache.headSha === headSha
+          packageInfoCache && (!headSha || packageInfoCache.headSha === headSha)
             ? packageInfoCache.packages
             : await listPackages(github, pullRequest),
       };


### PR DESCRIPTION
This can happen if the branch is deleted after the pull request is merged