### PR TITLE
ci: use published rollingversions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - build
       - run:
           name: Dry run
-          command: node packages/cli/lib/cli --dry-run
+          command: yarn global add rollingversions && rollingversions --dry-run
       - push
       - deploy:
           environment: staging
@@ -67,7 +67,7 @@ jobs:
       - build
       - run:
           name: Publish Packages
-          command: node packages/cli/lib/cli
+          command: yarn global add rollingversions && rollingversions
       - deploy:
           environment: production
 
@@ -101,9 +101,6 @@ commands:
       - run:
           name: Test
           command: yarn test
-      - run:
-          name: Dry run
-          command: node packages/cli/lib/cli --dry-run --supress-errors
 
   push:
     steps:


### PR DESCRIPTION
This means that if we break staging for some reason, we'll still be able to fix it and release the fixed version.