### PR TITLE
feat: use React svg icons with the ability to change the colours

### DIFF
--- a/packages/server/.storybook/main.js
+++ b/packages/server/.storybook/main.js
@@ -6,35 +6,57 @@ module.exports = {
   ],
   stories: ['../src/**/*.stories.tsx'],
   webpackFinal: async (config) => {
-    config.module.rules.push({
-      test: /\.tsx?$/,
-      include: [require('path').resolve(`${__dirname}/../src`)],
-      use: [
-        {
-          loader: require.resolve('ts-loader'),
-          options: {
-            compilerOptions: {module: 'ESNext'},
-            // use transpileOnly mode to speed-up compilation and avoid dealing with config errors
-            transpileOnly: true,
+    config.module.rules = [
+      {
+        oneOf: [
+          {
+            test: /\.tsx?$/,
+            include: [require('path').resolve(`${__dirname}/../src`)],
+            use: [
+              {
+                loader: require.resolve('ts-loader'),
+                options: {
+                  compilerOptions: {module: 'ESNext'},
+                  // use transpileOnly mode to speed-up compilation and avoid dealing with config errors
+                  transpileOnly: true,
+                },
+              },
+              {
+                loader: require.resolve('react-docgen-typescript-loader'),
+              },
+            ],
           },
-        },
-        {
-          loader: require.resolve('react-docgen-typescript-loader'),
-        },
-      ],
-    });
-    config.module.rules.forEach((rule) => {
-      if (Array.isArray(rule.use)) {
-        rule.use.forEach((loaderConfig) => {
-          if (/postcss\-loader/.test(loaderConfig.loader)) {
-            loaderConfig.options.plugins = [
-              require('tailwindcss'),
-              ...loaderConfig.options.plugins(),
-            ];
-          }
-        });
-      }
-    });
+          {
+            test: /\.svg$/,
+            include: [require('path').resolve(`${__dirname}/../src`)],
+            use: [
+              {
+                loader: require.resolve('react-svg-loader'),
+                options: {
+                  jsx: false,
+                  svgo: {
+                    plugins: [{uniqueID: require('svgo-unique-id')}],
+                  },
+                },
+              },
+            ],
+          },
+          ...config.module.rules.map((rule) => {
+            if (Array.isArray(rule.use)) {
+              rule.use.forEach((loaderConfig) => {
+                if (/postcss\-loader/.test(loaderConfig.loader)) {
+                  loaderConfig.options.plugins = [
+                    require('tailwindcss'),
+                    ...loaderConfig.options.plugins(),
+                  ];
+                }
+              });
+            }
+            return rule;
+          }),
+        ],
+      },
+    ];
     config.resolve.extensions.push('.ts', '.tsx');
     return config;
   },

--- a/packages/server/src/svg.ts
+++ b/packages/server/src/svg.ts
@@ -1,4 +1,9 @@
 declare module '*.svg' {
+  const SvgIcon: (props: React.SVGProps<SVGElement>) => React.ReactElement;
+  export default SvgIcon;
+}
+
+declare module '!url-loader!*.svg' {
   const url: string;
   export default url;
 }

--- a/packages/server/src/ui/visual/AppNavBar/index.tsx
+++ b/packages/server/src/ui/visual/AppNavBar/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Link} from 'react-router-dom';
 import Logo from '../Logo';
-import installIcon from '../HeroBar/install-icon.svg';
+import InstallIcon from '../HeroBar/install-icon.svg';
 
 export interface NavBarProps {
   children?: React.ReactNode;
@@ -16,7 +16,9 @@ export default function AppNavBar({children}: NavBarProps) {
       {React.Children.map(children, (child) => {
         return (
           <>
-            <img src={installIcon} className="w-auto h-4 mx-4" />
+            <div className="mx-4">
+              <InstallIcon className="w-auto h-4" />
+            </div>
             {child}
           </>
         );

--- a/packages/server/src/ui/visual/ContactsPage/contactMethod.tsx
+++ b/packages/server/src/ui/visual/ContactsPage/contactMethod.tsx
@@ -33,18 +33,13 @@ export default function ContactMethod({
   contactDescription: string;
   contactLink: string;
   contactAddress: string;
-  contactIcon: string;
+  contactIcon: React.ReactNode;
 }) {
   return (
     <div>
       <ContactDescription>{contactDescription}</ContactDescription>
       <ContactLink href={contactLink}>
-        <img
-          className="h-12 w-12"
-          src={contactIcon}
-          alt={contactDescription + ' Icon'}
-        />{' '}
-        {contactAddress}
+        {contactIcon} {contactAddress}
       </ContactLink>
     </div>
   );

--- a/packages/server/src/ui/visual/ContactsPage/contacts.tsx
+++ b/packages/server/src/ui/visual/ContactsPage/contacts.tsx
@@ -12,25 +12,45 @@ export default function Contacts() {
         contactDescription="Email"
         contactLink="mailto: hi@rollingversions.com?subject=Rolling Versions"
         contactAddress="hi@rollingversions.com"
-        contactIcon={EmailIcon}
+        contactIcon={
+          <EmailIcon className="h-12 w-12" aria-label="Email Icon" role="img" />
+        }
       />
       <ContactMethod
         contactDescription="Twitter"
         contactLink="https://twitter.com/RollingVersions"
         contactAddress="@rollingversions"
-        contactIcon={TwitterIcon}
+        contactIcon={
+          <TwitterIcon
+            className="h-12 w-12"
+            aria-label="Twitter Logo"
+            role="img"
+          />
+        }
       />
       <ContactMethod
         contactDescription="GitHub"
         contactLink="https://github.com/RollingVersions/RollingVersions"
         contactAddress="RollingVersions/RollingVersions"
-        contactIcon={GithubIcon}
+        contactIcon={
+          <GithubIcon
+            className="h-12 w-12"
+            aria-label="GitHub Logo"
+            role="img"
+          />
+        }
       />
       <ContactMethod
         contactDescription="Facebook"
         contactLink="https://www.facebook.com/RollingVersions/"
         contactAddress="Rolling Versions"
-        contactIcon={FacebookIcon}
+        contactIcon={
+          <FacebookIcon
+            className="h-12 w-12"
+            aria-label="Facebook Logo"
+            role="img"
+          />
+        }
       />
     </div>
   );

--- a/packages/server/src/ui/visual/DocsPage/docsFormats.tsx
+++ b/packages/server/src/ui/visual/DocsPage/docsFormats.tsx
@@ -3,8 +3,14 @@ import React from 'react';
 export function Heading({children}: {children: string}) {
   return <h2 className="font-poppins text-4xl">{children}</h2>;
 }
-export function Instruction({children}: {children: string}) {
-  return <h2 className="font-sans text-3xl">{children}</h2>;
+export function Instruction({
+  children,
+  className,
+}: {
+  children: string;
+  className?: string;
+}) {
+  return <h2 className={`font-sans text-3xl ${className}`}>{children}</h2>;
 }
 export function Details({children}: {children: React.ReactNode}) {
   return <p className="font-sans text-xl">{children}</p>;

--- a/packages/server/src/ui/visual/DocsPage/selector.tsx
+++ b/packages/server/src/ui/visual/DocsPage/selector.tsx
@@ -24,14 +24,13 @@ function SelectorButton({
   children: string;
   isSelected: boolean;
   onClick: () => void;
-  svgIcon?: any;
+  svgIcon: React.ReactNode;
 }) {
-  console.dir(svgIcon);
   return (
     <button
-      className={`btn h-56 w-56 ${
+      className={`flex flex-col items-center h-56 w-56 ${
         isSelected
-          ? 'bg-gray-400 border-4 '
+          ? 'bg-gray-300 border-4 '
           : 'bg-transparent hover:bg-gray-100 border hover:border-orange-300 '
       } font-poppins text-4xl py-2 px-4 border-orange-500 focus:outline-none focus:shadow-orange`}
       onClick={() => onClick()}
@@ -39,14 +38,12 @@ function SelectorButton({
       {/* <div className="flex justify-end">
         <Radio isSelected={isSelected} />
       </div> */}
-      <div className="flex flex-wrap justify-center">
-        {!svgIcon ? null : (
-          <div className="h-12 w-12">
-            <svg className="fill-current text-gray-900">{CircleCIicon}</svg>
-          </div>
-        )}
-        <p>{children}</p>
+      <div className="flex items-center justify-center flex-grow h-0">
+        <div className="h-12 w-12">{svgIcon}</div>
       </div>
+      <p className="flex items-center justify-center flex-grow h-0">
+        {children}
+      </p>
     </button>
   );
 }
@@ -62,23 +59,41 @@ export default function Selector({
 }) {
   return (
     <>
-      <Instruction>Select Continuous Integration Service</Instruction>
+      <Instruction className="mt-16">
+        Select Continuous Integration Service
+      </Instruction>
 
-      <div className="grid grid-cols-2 col-gap-12">
-        <SelectorButton
-          isSelected={selected === 'github-actions'}
-          onClick={() => setSelected('github-actions')}
-          svgIcon={GithubActionsIcon}
-        >
-          Github Actions
-        </SelectorButton>
-        <SelectorButton
-          isSelected={selected === 'circle-ci'}
-          onClick={() => setSelected('circle-ci')}
-          svgIcon={CircleCIicon}
-        >
-          Circle CI
-        </SelectorButton>
+      <div className="my-16 flex justify-center">
+        <div className="grid grid-cols-2 col-gap-12">
+          <SelectorButton
+            isSelected={selected === 'github-actions'}
+            onClick={() => setSelected('github-actions')}
+            svgIcon={
+              <GithubActionsIcon
+                className={`fill-current ${
+                  selected === 'github-actions'
+                    ? `text-orange-500`
+                    : `text-gray-700`
+                }`}
+              />
+            }
+          >
+            Github Actions
+          </SelectorButton>
+          <SelectorButton
+            isSelected={selected === 'circle-ci'}
+            onClick={() => setSelected('circle-ci')}
+            svgIcon={
+              <CircleCIicon
+                className={`fill-current ${
+                  selected === 'circle-ci' ? `text-orange-500` : `text-gray-900`
+                }`}
+              />
+            }
+          >
+            Circle CI
+          </SelectorButton>
+        </div>
       </div>
     </>
   );

--- a/packages/server/src/ui/visual/HeroBar/index.tsx
+++ b/packages/server/src/ui/visual/HeroBar/index.tsx
@@ -1,18 +1,8 @@
 import React from 'react';
-import installIcon from './install-icon.svg';
-import background from './background-image.svg';
+import InstallIcon from './install-icon.svg';
+// tslint:disable-next-line:no-implicit-dependencies
+import background from '!url-loader!./background-image.svg';
 
-export function InstallIcon({className}: {className: string}) {
-  return (
-    <img
-      aria-hidden={true}
-      width="49"
-      height="75"
-      className={className}
-      src={installIcon}
-    />
-  );
-}
 export function InstallButton({size = 'sm'}: {size?: 'sm' | 'lg'}) {
   return (
     <a
@@ -23,7 +13,10 @@ export function InstallButton({size = 'sm'}: {size?: 'sm' | 'lg'}) {
     >
       INSTALL
       <div className={size === 'lg' ? 'w-3' : 'w-2'} />
-      <InstallIcon className={size === 'lg' ? 'h-8 w-auto' : 'h-6 w-auto'} />
+      <InstallIcon
+        aria-hidden={true}
+        className={size === 'lg' ? 'h-8 w-auto' : 'h-6 w-auto'}
+      />
     </a>
   );
 }

--- a/packages/server/src/ui/visual/HeroBar/install-icon.svg
+++ b/packages/server/src/ui/visual/HeroBar/install-icon.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="49" height="75" viewBox="0 0 49 75"><g><g><path fill="#ff8000" d="M0 0v75l48.93-37.817z"/></g></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 49 75"><g><g><path fill="#ff8000" d="M0 0v75l48.93-37.817z"/></g></g></svg>

--- a/packages/server/src/ui/visual/Logo/index.tsx
+++ b/packages/server/src/ui/visual/Logo/index.tsx
@@ -6,16 +6,13 @@ export default function Logo({
   dark,
   ...props
 }: Omit<
-  React.ImgHTMLAttributes<HTMLImageElement>,
-  'width' | 'height' | 'src'
-> & {dark?: boolean}) {
-  return (
-    <img
-      alt="Rolling Versions"
-      {...props}
-      width="180px"
-      height="47px"
-      src={dark ? WordmarkDark : Wordmark}
-    />
-  );
+  React.SVGProps<SVGElement>,
+  'width' | 'height' | 'viewBox' | 'xmlns'
+> & {
+  dark?: boolean;
+}) {
+  if (dark) {
+    return <WordmarkDark {...props} />;
+  }
+  return <Wordmark {...props} />;
 }

--- a/packages/server/src/ui/visual/Logo/wordmark-dark.svg
+++ b/packages/server/src/ui/visual/Logo/wordmark-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="180" height="47" viewBox="0 0 180 47">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 47">
   <g fill="none" fill-rule="evenodd" transform="translate(0 1)">
     <rect width="44.83" height="44.83" x=".69" y=".23" stroke="#FFF" stroke-width=".602"/>
     <rect width="37.618" height="37.618" x="10.335" y="5.295" stroke="#FFF" stroke-width=".602" transform="rotate(-82.998 29.145 24.104)"/>

--- a/packages/server/src/ui/visual/Logo/wordmark.svg
+++ b/packages/server/src/ui/visual/Logo/wordmark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="180" height="47" viewBox="0 0 180 47">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 47">
   <g fill="none" fill-rule="evenodd" transform="translate(0 1)">
     <g transform="translate(.69 .23)">
       <rect width="44.83" height="44.83" stroke="#000" stroke-width=".602"/>

--- a/packages/server/src/ui/visual/RepositoryPage/index.tsx
+++ b/packages/server/src/ui/visual/RepositoryPage/index.tsx
@@ -4,7 +4,7 @@ import changesToMarkdown from 'rollingversions/lib/utils/changesToMarkdown';
 import GitHubMarkdownAsync from '../GitHubMarkdown/async';
 import {RepoResponse} from '../../../types';
 import Alert from '../Alert';
-import {InstallIcon} from '../HeroBar';
+import InstallIcon from '../HeroBar/install-icon.svg';
 
 function PackageName({children}: {children: React.ReactNode}) {
   return (

--- a/packages/server/webpack.config.ts
+++ b/packages/server/webpack.config.ts
@@ -89,22 +89,21 @@ const config: webpack.Configuration = {
             ],
           },
 
-          // TODO: if we want to use SVGs as react elements instead.
-          // N.B. This would also need to update storybook
-          // {
-          //   test: /\.svg$/,
-          //   use: [
-          //     {
-          //       loader: require.resolve('react-svg-loader'),
-          //       options: {
-          //         jsx: false,
-          //         svgo: {
-          //           plugins: [{uniqueID: require('svgo-unique-id')}],
-          //         },
-          //       },
-          //     },
-          //   ],
-          // },
+          {
+            test: /\.svg$/,
+            include: [require('path').resolve(`${__dirname}/src`)],
+            use: [
+              {
+                loader: require.resolve('react-svg-loader'),
+                options: {
+                  jsx: false,
+                  svgo: {
+                    plugins: [{uniqueID: require('svgo-unique-id')}],
+                  },
+                },
+              },
+            ],
+          },
 
           // "url" loader works like "file" loader except that it embeds assets
           // smaller than specified limit in bytes as data URLs to avoid requests.


### PR DESCRIPTION
This changes to webpack config so that the icons are rendered as inline SVG with React, instead of via `<img>` tags. This lets you change the colour of them dynamically using tailwind css.