### PR TITLE
Docs adjustments

### DIFF
--- a/packages/server/src/ui/visual/DocsPage/index.tsx
+++ b/packages/server/src/ui/visual/DocsPage/index.tsx
@@ -15,7 +15,7 @@ export default function DocsPage({
       <HeroBar>
         <p>Docs</p>
       </HeroBar>
-      <div className="py-16 container mx-auto">
+      <div className="py-16 container mx-auto ">
         <Docs selected={selected} links={links} />
       </div>
       <HeroBarFooter />

--- a/packages/server/src/ui/visual/DocsPage/index.tsx
+++ b/packages/server/src/ui/visual/DocsPage/index.tsx
@@ -15,7 +15,7 @@ export default function DocsPage({
       <HeroBar>
         <p>Docs</p>
       </HeroBar>
-      <div className="py-16 container mx-auto ">
+      <div className="py-16 container mx-auto">
         <Docs selected={selected} links={links} />
       </div>
       <HeroBarFooter />

--- a/packages/server/src/ui/visual/DocsPage/selector.tsx
+++ b/packages/server/src/ui/visual/DocsPage/selector.tsx
@@ -17,11 +17,11 @@ function SelectorButton({
 }) {
   return (
     <Link
-      className={`flex flex-col items-center h-56 w-56 ${
+      className={`flex flex-col items-center h-48 w-48 md:h-56 md:w-56 ${
         isSelected
           ? 'bg-gray-300 border-4 '
           : 'bg-transparent hover:bg-gray-100 border hover:border-orange-300 '
-      } font-poppins text-4xl py-2 px-4 border-orange-500 focus:outline-none focus:shadow-orange`}
+      } font-poppins text-3xl md:text-4xl py-2 px-4 border-orange-500 focus:outline-none focus:shadow-orange`}
       to={to}
       onMouseUp={(e) => {
         e.currentTarget.blur();
@@ -51,7 +51,7 @@ export default function Selector({
       </Instruction>
 
       <div className="my-8 flex justify-center">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-12">
+        <div className="grid grid-cols-1 xs:grid-cols-2 gap-12">
           <SelectorButton
             isSelected={selected === 'github-actions'}
             to={links['github-actions']}

--- a/packages/server/src/ui/visual/DocsPage/selector.tsx
+++ b/packages/server/src/ui/visual/DocsPage/selector.tsx
@@ -4,18 +4,6 @@ import {Instruction} from './docsFormats';
 import GithubActionsIcon from '../../icons/githubactions.svg';
 import CircleCIicon from '../../icons/circleci.svg';
 
-// function Radio({isSelected}: {isSelected: boolean}) {
-//   return (
-//     <div className="flex justify-center items-center border border-solid border-gray-800 border-6 rounded-full h-12 w-12">
-//       {!isSelected ? null : (
-//         <div className="bg-orange-500 border rounded-full h-8 w-8"></div>
-//       )}
-//     </div>
-//   );
-// }
-
-// TODO This looks horrible! I have been trying to get rid of blue outline when focussed/active but haven't succeeded.  I've tried ' outline-none focus:shadow-outline' and the outline is more shadowy but there all the time.
-
 function SelectorButton({
   children,
   isSelected,
@@ -39,9 +27,6 @@ function SelectorButton({
         e.currentTarget.blur();
       }}
     >
-      {/* <div className="flex justify-end">
-        <Radio isSelected={isSelected} />
-      </div> */}
       <div className="flex items-center justify-center flex-grow h-0">
         <div className="h-12 w-12">{svgIcon}</div>
       </div>
@@ -65,7 +50,7 @@ export default function Selector({
         Select Continuous Integration Service
       </Instruction>
 
-      <div className="my-16 flex justify-center">
+      <div className="my-8 flex justify-center">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-12">
           <SelectorButton
             isSelected={selected === 'github-actions'}

--- a/packages/server/tailwind.config.js
+++ b/packages/server/tailwind.config.js
@@ -1,4 +1,4 @@
-const {colors} = require('tailwindcss/defaultTheme');
+const {colors, screens} = require('tailwindcss/defaultTheme');
 
 module.exports = {
   theme: {
@@ -78,6 +78,7 @@ module.exports = {
 
     screens: {
       xs: '500px',
+      ...screens,
     },
   },
 

--- a/packages/server/tailwind.config.js
+++ b/packages/server/tailwind.config.js
@@ -75,6 +75,10 @@ module.exports = {
       orange: '0 0 0 6px hsl(30, 100%, 50%, 20%)',
       gray: '0 0 0 6px hsl(218, 23%, 23%, 20%)',
     },
+
+    screens: {
+      xs: '500px',
+    },
   },
 
   variants: {},


### PR DESCRIPTION
This

- Removes some old commented out code and TODOs
- Reduces the vertical spacing on the selector - to avoid a disconnect with the instruction above
- Reduces button and text sizes on small screens
- Introduces an xs screen size/break point in the tailwind.config

My reasoning for the xs screen size is that when the buttons are vertical then clicking the links doesn't obviously display the next lot of text - you have to scroll quite a way (I know people can scroll but they have to realise that they need to and that something has changed).

Introducing the xs screen size and slightly smaller buttons means that mobiles in landscape and tablets in portrait (the latter being key) can still display them side by side which makes it slightly more obvious what is happening/what to do.

### **ISSUE**
Introducing the screen size upsets the margin useage on the small screen sizes everywhere (centring the text and creating over-large margins), but I can't work out where this is set.  Something to do with mx-auto?
