### PR TITLE
perf: only send owner and name to GItHub

### DIFF
--- a/packages/cli/src/services/github/index.ts
+++ b/packages/cli/src/services/github/index.ts
@@ -198,7 +198,8 @@ export async function* getAllFiles(
           getContents: async () => {
             const file = await retry(() =>
               gh.getFile(client, {
-                ...repo,
+                owner: repo.owner,
+                name: repo.name,
                 oid,
               }),
             );


### PR DESCRIPTION
It was polluting logs and reducing performance.