### PR TITLE
feat: rate limit clients

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,7 @@
     "postbuild": "rimraf lib/**/{__tests__,__mock_services__}"
   },
   "dependencies": {
-    "@github-graph/api": "^2.0.0",
+    "@github-graph/api": "^2.2.0",
     "@types/semver": "^7.1.0",
     "assert-never": "^1.2.0",
     "chalk": "^3.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,7 @@
     "postbuild": "rimraf lib/**/{__tests__,__mock_services__}"
   },
   "dependencies": {
-    "@github-graph/api": "^2.2.0",
+    "@github-graph/api": "^2.2.1",
     "@types/semver": "^7.1.0",
     "assert-never": "^1.2.0",
     "chalk": "^3.0.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -26,7 +26,7 @@
     "@authentication/github": "^0.2.0",
     "@authentication/lock-by-id": "^0.0.2",
     "@databases/pg": "^2.1.2",
-    "@github-graph/api": "^2.0.0",
+    "@github-graph/api": "^2.2.0",
     "@octokit/webhooks": "^7.1.0",
     "@types/morgan": "^1.9.0",
     "@types/on-finished": "^2.3.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -26,7 +26,7 @@
     "@authentication/github": "^0.2.0",
     "@authentication/lock-by-id": "^0.0.2",
     "@databases/pg": "^2.1.2",
-    "@github-graph/api": "^2.2.0",
+    "@github-graph/api": "^2.2.1",
     "@octokit/webhooks": "^7.1.0",
     "@types/morgan": "^1.9.0",
     "@types/on-finished": "^2.3.1",

--- a/packages/server/src/server/getClient.ts
+++ b/packages/server/src/server/getClient.ts
@@ -5,7 +5,12 @@ import isObject from '../utils/isObject';
 import withCache from '../utils/withCache';
 import log from './logger';
 
-function addLogging(options: GitHubOptions): GitHubOptions {
+function addLogging(
+  options: Omit<
+    GitHubOptions,
+    'rateLimitOptions' | 'onBatchRequest' | 'onBatchResponse' | 'onResponse'
+  >,
+): GitHubOptions {
   const starts = new WeakMap<
     {
       query: string;
@@ -15,6 +20,10 @@ function addLogging(options: GitHubOptions): GitHubOptions {
   >();
   return {
     ...options,
+    rateLimitOptions: {
+      maxSize: 300,
+      interval: 2000,
+    },
     onBatchRequest(req) {
       starts.set(req, Date.now());
     },

--- a/packages/server/src/server/services/github/index.ts
+++ b/packages/server/src/server/services/github/index.ts
@@ -1,4 +1,7 @@
-import GitHubClient, {auth, Options as GitHubOptions} from '@github-graph/api';
+import GitHubClient, {
+  auth,
+  OptionsWithAuth as GitHubOptions,
+} from '@github-graph/api';
 import {Repository} from 'rollingversions/lib/types';
 import paginateBatched from 'rollingversions/lib/services/github/paginateBatched';
 import isTruthy from 'rollingversions/lib/ts-utils/isTruthy';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1263,10 +1263,10 @@
     postcss "7.0.27"
     purgecss "^2.1.0"
 
-"@github-graph/api@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@github-graph/api/-/api-2.2.0.tgz#cf673736f0fefe02f3d49cfe835a8ed3f04de7b1"
-  integrity sha512-grfHQES/a7xwt7O6WAc8pwSuOoXKSRScstegV6Tg8Gj7LL34mJ7zVAEYWTMVBaw4gd/5X2zdESirkhRmaq0RoA==
+"@github-graph/api@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@github-graph/api/-/api-2.2.1.tgz#13b07587a8d0c6128c6d7e3c41bc12ad996a11fb"
+  integrity sha512-pdVF09SDLePrBCKSOdVPsV0Bb9l1GxHwjiD+skNH7vC6cki3dcPq/oA73zQc1xC6t0HT+125BwS2fEvdBkUY4A==
   dependencies:
     "@authentication/rate-limit" "^0.0.7"
     "@octokit/auth" "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -91,6 +91,15 @@
     "@types/express" "^4.0.39"
     oauth "^0.9.15"
 
+"@authentication/rate-limit@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@authentication/rate-limit/-/rate-limit-0.0.7.tgz#a152f7a7d7c7be23907c5215d83bde8a582d72ee"
+  integrity sha512-uonLdxfQjqJMWTnoFcSMDlkt5tmfPYKVQU26hcDeIiwSQw2p7XU1gpnbxNDUyEPDgYEBeMKLInhD+6HnVdvvYQ==
+  dependencies:
+    "@authentication/lock-by-id" "^0.0.2"
+    "@types/ms" "^0.7.30"
+    ms "^2.1.1"
+
 "@authentication/raw-cookie@^0.0.2":
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/@authentication/raw-cookie/-/raw-cookie-0.0.2.tgz#e521fd6672a5e89073fe631b64cbb625bd9c14b9"
@@ -1254,11 +1263,12 @@
     postcss "7.0.27"
     purgecss "^2.1.0"
 
-"@github-graph/api@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@github-graph/api/-/api-2.0.0.tgz#b992018331c5a99913ddd0526ce960616fe10840"
-  integrity sha512-S4rWb0Y9N6f7SINYtsIgu3/DPUOLgIZe1ResQO52ZJiPEiDl1sWFijprlYVVGgvE89JFWv2pRULLeKjDRoU/hw==
+"@github-graph/api@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@github-graph/api/-/api-2.2.0.tgz#cf673736f0fefe02f3d49cfe835a8ed3f04de7b1"
+  integrity sha512-grfHQES/a7xwt7O6WAc8pwSuOoXKSRScstegV6Tg8Gj7LL34mJ7zVAEYWTMVBaw4gd/5X2zdESirkhRmaq0RoA==
   dependencies:
+    "@authentication/rate-limit" "^0.0.7"
     "@octokit/auth" "^2.0.0"
     "@octokit/request" "^5.3.2"
     "@octokit/rest" "^17.1.0"
@@ -2401,6 +2411,11 @@
   integrity sha512-warrzirh5dlTMaETytBTKR886pRXwr+SMZD87ZE13gLMR8Pzz69SiYFkvoDaii78qGP1iyBIUYz5GiXyryO//A==
   dependencies:
     "@types/express" "*"
+
+"@types/ms@^0.7.30":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
 "@types/node-fetch@2.5.5":
   version "2.5.5"


### PR DESCRIPTION
By rate limiting on our side to burts of 300 requests and only 1 request every 2 seconds, we ensure that one mis-behaving repository cannot consume the entire rate limit for the Rolling Versions application.