### PR TITLE
feat: custom tag format for custom script deployments

### DIFF
--- a/packages/cli/src/types/PublishTarget.ts
+++ b/packages/cli/src/types/PublishTarget.ts
@@ -27,6 +27,7 @@ export interface CustomScriptTargetConfig {
   prepublish?: string;
   publish_dry_run?: string;
   publish: string;
+  tag_format?: string;
 }
 export const CustomScriptTargetConfig: t.Codec<CustomScriptTargetConfig> = t
   .Object({
@@ -38,6 +39,7 @@ export const CustomScriptTargetConfig: t.Codec<CustomScriptTargetConfig> = t
       version: t.String,
       prepublish: t.String,
       publish_dry_run: t.String,
+      tag_format: t.String,
     }),
   );
 

--- a/packages/cli/src/utils/__tests__/getVersionTag.test.ts
+++ b/packages/cli/src/utils/__tests__/getVersionTag.test.ts
@@ -1,0 +1,104 @@
+import getVersionTag from '../getVersionTag';
+
+test('getVersionTag', () => {
+  expect(
+    getVersionTag([{name: 'foo-bar'}], 'my-package', null, {
+      repoHasMultiplePackages: false,
+      tagFormat: null,
+    }),
+  ).toMatchInlineSnapshot(`null`);
+  expect(
+    getVersionTag([{name: 'foo-bar'}], 'my-package', '1.0.0', {
+      repoHasMultiplePackages: false,
+      tagFormat: null,
+    }),
+  ).toMatchInlineSnapshot(`null`);
+  expect(
+    getVersionTag([{name: '1.0.0'}], 'my-package', '1.0.0', {
+      repoHasMultiplePackages: false,
+      tagFormat: null,
+    }),
+  ).toMatchInlineSnapshot(`
+    Object {
+      "name": "1.0.0",
+      "version": "1.0.0",
+    }
+  `);
+  expect(
+    getVersionTag([{name: 'my-package@1.0.0'}], 'my-package', '1.0.0', {
+      repoHasMultiplePackages: false,
+      tagFormat: null,
+    }),
+  ).toMatchInlineSnapshot(`
+    Object {
+      "name": "my-package@1.0.0",
+      "version": "1.0.0",
+    }
+  `);
+  expect(
+    getVersionTag([{name: '1.0.0'}], 'my-package', '1.0.0', {
+      repoHasMultiplePackages: true,
+      tagFormat: null,
+    }),
+  ).toMatchInlineSnapshot(`null`);
+  expect(
+    getVersionTag([{name: 'my-package@1.0.0'}], 'my-package', '1.0.0', {
+      repoHasMultiplePackages: true,
+      tagFormat: null,
+    }),
+  ).toMatchInlineSnapshot(`
+    Object {
+      "name": "my-package@1.0.0",
+      "version": "1.0.0",
+    }
+  `);
+});
+
+test('Custom tag format', () => {
+  expect(
+    getVersionTag([{name: '0-4-5'}], 'my-package', null, {
+      repoHasMultiplePackages: true,
+      tagFormat: '{{PATCH}}-{{MINOR}}-{{MAJOR}}',
+    }),
+  ).toMatchInlineSnapshot(`
+    Object {
+      "name": "0-4-5",
+      "version": "5.4.0",
+    }
+  `);
+  expect(
+    getVersionTag([{name: '0-4-5'}], 'my-package', '5.4.0', {
+      repoHasMultiplePackages: true,
+      tagFormat: '{{PATCH}}-{{MINOR}}-{{MAJOR}}',
+    }),
+  ).toMatchInlineSnapshot(`
+    Object {
+      "name": "0-4-5",
+      "version": "5.4.0",
+    }
+  `);
+  expect(
+    getVersionTag([{name: 'before-0-4-5-after'}], 'my-package', '5.4.0', {
+      repoHasMultiplePackages: true,
+      tagFormat: 'before-{{PATCH}}-{{MINOR}}-{{MAJOR}}-after',
+    }),
+  ).toMatchInlineSnapshot(`
+    Object {
+      "name": "before-0-4-5-after",
+      "version": "5.4.0",
+    }
+  `);
+});
+
+// import {valid, prerelease, gt} from 'semver';
+// import isTruthy from '../ts-utils/isTruthy';
+// import parseVersionTagTemplate from './parseVersionTagTemplate';
+
+// export default function getVersionTag<Tag extends {readonly name: string}>(
+//   allTags: readonly Tag[],
+//   packageName: string,
+//   registryVersion: string | null,
+//   {isMonoRepo, tagFormat}: {isMonoRepo: boolean; tagFormat: string | null},
+// ): (Tag & {version: string}) | null {
+
+// }

--- a/packages/cli/src/utils/addPackageVersions.ts
+++ b/packages/cli/src/utils/addPackageVersions.ts
@@ -2,6 +2,7 @@ import {
   PackageManifest,
   PackageDependencies,
   PackageManifestWithVersion,
+  PublishTarget,
 } from '../types';
 import {getRegistryVersion as GetRegistryVersionType} from '../PublishTargets';
 import getVersionTag from './getVersionTag';
@@ -37,6 +38,13 @@ export default async function addPackageVersions(
             },
           ]
         > => {
+          const tagFormat = manifests
+            .map(
+              (m) =>
+                m.targetConfig.type === PublishTarget.custom_script &&
+                m.targetConfig.tag_format,
+            )
+            .find((m) => m);
           return [
             packageName,
             {
@@ -51,7 +59,10 @@ export default async function addPackageVersions(
                         allTags,
                         packageName,
                         registryVersion,
-                        {isMonoRepo: packages.size > 1},
+                        {
+                          repoHasMultiplePackages: packages.size > 1,
+                          tagFormat: tagFormat || null,
+                        },
                       ),
                     };
                   },

--- a/packages/cli/src/utils/getNewTagName.ts
+++ b/packages/cli/src/utils/getNewTagName.ts
@@ -1,7 +1,9 @@
+import {PublishTarget} from '../types';
 import {
   SuccessPackageStatus,
   NewVersionToBePublished,
 } from './getPackageStatuses';
+import parseVersionTagTemplate from './parseVersionTagTemplate';
 
 /**
  * If you start with RollingVersions from scratch, we always use the tag format:
@@ -60,6 +62,22 @@ export default function getNewTagName(
   allPackages: readonly SuccessPackageStatus[],
   pkg: NewVersionToBePublished,
 ) {
+  const tagFormat = pkg.manifests
+    .map(
+      (m) =>
+        m.targetConfig.type === PublishTarget.custom_script &&
+        m.targetConfig.tag_format,
+    )
+    .find((m) => m);
+  if (tagFormat) {
+    const [MAJOR, MINOR, PATCH] = pkg.newVersion.split('.');
+    return parseVersionTagTemplate(tagFormat).applyTemplate({
+      PACKAGE_NAME: pkg.packageName,
+      MAJOR,
+      MINOR,
+      PATCH,
+    });
+  }
   const start = isSinglePackageWithDirectVersion(allPackages)
     ? ``
     : `${pkg.packageName}@`;

--- a/packages/cli/src/utils/parseVersionTagTemplate.ts
+++ b/packages/cli/src/utils/parseVersionTagTemplate.ts
@@ -1,0 +1,151 @@
+export interface Version {
+  PACKAGE_NAME: string;
+  MAJOR: string;
+  MINOR: string;
+  PATCH: string;
+}
+function isValidVariable(
+  variable: string,
+): variable is 'PACKAGE_NAME' | 'MAJOR' | 'MINOR' | 'PATCH' {
+  switch (variable) {
+    case 'PACKAGE_NAME':
+    case 'MAJOR':
+    case 'MINOR':
+    case 'PATCH':
+      return true;
+    default:
+      return false;
+  }
+}
+export default function parseVersionTagTemplate(str: string) {
+  const variables = [];
+  const printer: ((values: Version) => string)[] = [];
+  const parser: ((
+    str: string,
+    packageName: string,
+  ) => null | {rest: string; parsed: Partial<Version>})[] = [];
+  let inVariables = false;
+  for (const part of str.split('{{')) {
+    if (inVariables) {
+      const split = part.split('}}');
+      if (split.length !== 2) {
+        throw new Error(`Mismatched parentheses: ${str}`);
+      }
+      const [variable, plainString] = split;
+      if (!isValidVariable(variable)) {
+        throw new Error(`${variable} is not a valid variable: ${str}`);
+      }
+      variables.push(variable);
+      printer.push((version) => version[variable]);
+      parser.push((str, packageName) => {
+        switch (variable) {
+          case 'PACKAGE_NAME':
+            return str.startsWith(packageName)
+              ? {
+                  rest: str.substring(packageName.length),
+                  parsed: {PACKAGE_NAME: packageName},
+                }
+              : null;
+          case 'MAJOR':
+          case 'MINOR':
+          case 'PATCH':
+            const match = /^\d+/.exec(str);
+            return match
+              ? {
+                  rest: str.substring(match[0].length),
+                  parsed: {[variable]: match[0]},
+                }
+              : null;
+        }
+      });
+      printer.push(() => plainString);
+      parser.push((str) =>
+        str.startsWith(plainString)
+          ? {rest: str.substring(plainString.length), parsed: {}}
+          : null,
+      );
+      // TODO: support some basic "filters"
+      // const [placeholder, plainString] = split;
+      // const [variable, ...filters] = placeholder
+      //   .split('|')
+      //   .map((str) => str.trim());
+      // variables.push(variable);
+      // for (const filter of filters) {
+      //   const [filterName, ...params] = filter.split(' ');
+      //   switch (filterName) {
+      //     case 'pascal-case':
+      //     case 'camel-case':
+      //       assert(
+      //         params.length === 0,
+      //         `The ${filterName} filter does not accept any parameters: ${str}`,
+      //       );
+      //       break;
+      //     case 'pad-start':
+      //     case 'pad-end':
+      //       assert(
+      //         params.length > 0 && params.length < 3,
+      //         `The ${filterName} filter requires between 1 and 2 parameters: ${str}`,
+      //       );
+      //       assert(
+      //         /^[0-9]+$/.test(params[0]),
+      //         `The first parameter for the ${filterName} fitler must be an integer: ${str}`,
+      //       );
+      //       break;
+      //     default:
+      //       throw new Error(
+      //         `Unrecognized filter in type generation config, "${filter}" in: ${str}`,
+      //       );
+      //   }
+      // }
+
+      // result.push((values) => {
+      //   if (!(variable in values)) {
+      //     throw new Error(`Unrecognized variable ${variable} in ${str}`);
+      //   }
+      //   return filters.reduce<string>((value, filter): string => {
+      //     const [filterName, ...params] = filter.split(' ');
+      //     switch (filterName) {
+      //       case 'pascal-case':
+      //         return camelcase(value, {locale: 'en-US', pascalCase: true});
+      //       case 'camel-case':
+      //         return camelcase(value, {locale: 'en-US'});
+      //       case 'pad-start':
+      //         return value.padStart(parseInt(params[0], 10), params[1]);
+      //       case 'pad-end':
+      //         return value.padEnd(parseInt(params[0], 10), params[1]);
+      //       default:
+      //         throw new Error(
+      //           `Unrecognized filter in type generation config, "${filter}" in: ${str}`,
+      //         );
+      //     }
+      //   }, values[variable]);
+      // });
+      printer.push(() => plainString);
+    } else {
+      inVariables = true;
+      printer.push(() => part);
+      parser.push((str) =>
+        str.startsWith(part)
+          ? {rest: str.substring(part.length), parsed: {}}
+          : null,
+      );
+    }
+  }
+
+  return {
+    variables,
+    parse: (tag: string, packageName: string) => {
+      let rest = tag;
+      const result: Partial<Version> = {};
+      for (const part of parser) {
+        const partResult = part(rest, packageName);
+        if (!partResult) return partResult;
+        rest = partResult.rest;
+        Object.assign(result, partResult.parsed);
+      }
+      if (rest) return null;
+      return result;
+    },
+    applyTemplate: (value: Version) => printer.map((r) => r(value)).join(''),
+  };
+}


### PR DESCRIPTION
This lets you format your tags any way you like, as long as they have a MAJOR, MINOR and PATCH version.