### PR TITLE
fix: handle custom tags with padded numbers

### DIFF
--- a/packages/cli/src/utils/__tests__/getNewTagName.test.ts
+++ b/packages/cli/src/utils/__tests__/getNewTagName.test.ts
@@ -27,4 +27,30 @@ test('getNewTagName', () => {
       dependencies: {required: [], optional: [], development: []},
     }),
   ).toMatchInlineSnapshot(`"1/0/0"`);
+
+  expect(
+    getNewTagName([], {
+      status: PackageStatus.NewVersionToBePublished,
+      packageName: 'my-package-name',
+      currentVersion: null,
+      newVersion: '1.0.0',
+      changeSet: {breaking: [], feat: [], refactor: [], perf: [], fix: []},
+      manifests: [
+        {
+          registryVersion: null,
+          versionTag: null,
+          path: 'some/path',
+          packageName: 'my-package-name',
+          notToBePublished: false,
+          targetConfig: {
+            type: PublishTarget.custom_script,
+            publish: 'echo published',
+            tag_format:
+              '{{MAJOR | pad-number 4}}/{{MINOR | pad-number 3}}/{{PATCH | pad-number 6}}',
+          },
+        },
+      ],
+      dependencies: {required: [], optional: [], development: []},
+    }),
+  ).toMatchInlineSnapshot(`"0001/000/000000"`);
 });

--- a/packages/cli/src/utils/__tests__/getVersionTag.test.ts
+++ b/packages/cli/src/utils/__tests__/getVersionTag.test.ts
@@ -88,6 +88,24 @@ test('Custom tag format', () => {
       "version": "5.4.0",
     }
   `);
+
+  expect(
+    getVersionTag(
+      [{name: 'before-0-4-5-after'}, {name: 'before-0-04-006-after'}],
+      'my-package',
+      null,
+      {
+        repoHasMultiplePackages: true,
+        tagFormat:
+          'before-{{ PATCH | pad-number 2 }}-{{ MINOR | pad-number 2 }}-{{ MAJOR | pad-number 3 }}-after',
+      },
+    ),
+  ).toMatchInlineSnapshot(`
+    Object {
+      "name": "before-0-04-006-after",
+      "version": "6.4.0",
+    }
+  `);
 });
 
 // import {valid, prerelease, gt} from 'semver';

--- a/packages/cli/src/utils/getVersionTag.ts
+++ b/packages/cli/src/utils/getVersionTag.ts
@@ -19,8 +19,10 @@ export default function getVersionTag<Tag extends {readonly name: string}>(
         if (parsed) {
           return {
             ...tag,
-            version: `${parsed.MAJOR || 0}.${parsed.MINOR ||
-              0}.${parsed.PATCH || 0}`,
+            version: `${parseInt(parsed.MAJOR || '0', 10)}.${parseInt(
+              parsed.MINOR || '0',
+              10,
+            )}.${parseInt(parsed.PATCH || '0', 10)}`,
           };
         } else {
           return null;


### PR DESCRIPTION
This enables the custom tag parser to read versions where the numbers are padded. It also adds the option of applying a "filter" to padd your version numbers, e.g. `{{MAJOR | pad-number 4}}.{{MINOR | pad-number 2}}.{{PATCH | pad-number 2}}` would ensure the major version always had at least 4 digits, minor always had at least 2 and patch always had at least 2