### PR TITLE
perf: only run one replica of the app

### DIFF
--- a/.kube/deployment.ts
+++ b/.kube/deployment.ts
@@ -19,7 +19,7 @@ export default createDeployment({
   namespace: 'rollingversions',
   name: 'rollingversions-' + process.env.ENVIRONMENT,
   containerPort: 3000,
-  replicaCount: 2,
+  replicaCount: 1,
   image: `${process.env.DOCKERHUB_USERNAME}/rollingversions:${process.env.CIRCLE_SHA1}`,
   container: {
     env: [{name: 'ENV_VAR', value: 'Hello Env Var'}],


### PR DESCRIPTION
Running multiple replicas uses way more CPU & RAM on my cluster. It also makes the in-process caches drastically less efficient. Finally, it results in way more conflicts when writing to the database because attempts to only update each repo once break down when running 2 servers.

The backend load is nowhere near needing horizontal scaling of the server.