### PR TITLE
perf: load repo files using git

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,6 @@
     "assert-never": "^1.2.0",
     "chalk": "^3.0.0",
     "cross-fetch": "^3.1.4",
-    "dataloader": "^2.0.0",
     "detect-indent": "^6.0.0",
     "detect-newline": "^3.1.0",
     "env-ci": "^5.0.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -23,6 +23,7 @@
     "@authentication/github": "^0.2.0",
     "@authentication/lock-by-id": "^0.0.2",
     "@github-graph/api": "^2.2.1",
+    "@mavenoid/dataloader": "^3.1.0",
     "@octokit/webhooks": "^7.1.0",
     "@rollingversions/change-set": "^0.0.0",
     "@rollingversions/config": "0.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1717,6 +1717,11 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@mavenoid/dataloader@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@mavenoid/dataloader/-/dataloader-3.1.0.tgz#4a399788d06d90b6e68cad05eda2a1191ee3c97e"
+  integrity sha512-M2qUTENzUnppoLnjL5elnNamc1Cvzd6SjfPpE0XkjqsOoVU1WDHM7beGfaSwgt2ySR9Jvghb6McQjdP68/+D5Q==
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -6044,11 +6049,6 @@ data-urls@^2.0.0:
     abab "^2.0.3"
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
-
-dataloader@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.0.0.tgz#41eaf123db115987e21ca93c005cd7753c55fe6f"
-  integrity sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==
 
 date-fns@^1.27.2:
   version "1.30.1"


### PR DESCRIPTION
This makes us less reliant on the GitHub GraphQL API, which can time out when listing very large repositories.